### PR TITLE
Extend makefile for jar download and autocompiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.class
 *.swp
+*.jar

--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ clean:
 	rm -f Matrix.class
 	rm -f MatrixTest.class
 
-test:  Matrix.class MatrixTest.class
+test:  Matrix.class MatrixTest.class $(JUNIT_JAR) $(HAMCREST_JAR)
 	java -cp .:$(JUNIT_JAR):$(HAMCREST_JAR) org.junit.runner.JUnitCore MatrixTest
 
 # Add makefile targets that download the jars automatically if they

--- a/makefile
+++ b/makefile
@@ -12,16 +12,27 @@
 # #
 #
 
-JUNIT_JAR = /usr/share/java/junit-4.10.jar
-HAMCREST_JAR = /usr/share/java/hamcrest/core-1.1.jar
+# Set up locations for the jar files and URIs to fetch them from.
+JUNIT_JAR = junit-4.12.jar
+JUNIT_URI = https://github.com/junit-team/junit4/releases/download/r4.12/$(JUNIT_JAR)
+HAMCREST_JAR = hamcrest-core-1.3.jar
+HAMCREST_URI = http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/$(HAMCREST_JAR)
+CLASSPATH = -cp .:$(JUNIT_JAR)
+CC = javac $(CLASSPATH)
+
+# Teach make how to use javac to convert between .java and .class
+.SUFFIXES: .java .class
+.java.class:
+	$(CC) $<
 
 default:
 	@echo "usage: make target"
 	@echo "available targets: compile, test, clean"
 
-compile: Matrix.java MatrixTest.java
-	javac -cp .:$(JUNIT_JAR) MatrixTest.java
-	javac Matrix.java
+compile: Matrix.class MatrixTest.class
+	@echo "compiled"
+	
+MatrixTest.class: $(JUNIT_JAR)
 
 clean:
 	rm -f Matrix.class
@@ -30,6 +41,9 @@ clean:
 test:  Matrix.class MatrixTest.class
 	java -cp .:$(JUNIT_JAR):$(HAMCREST_JAR) org.junit.runner.JUnitCore MatrixTest
 
-
-
-
+# Add makefile targets that download the jars automatically if they
+# are not present locally.
+$(JUNIT_JAR):
+	curl $(JUNIT_URI) -o $(JUNIT_JAR) --silent --location
+$(HAMCREST_JAR):
+	curl $(HAMCREST_URI) -o $(HAMCREST_JAR) --silent --location


### PR DESCRIPTION
This adds makefile targets that download the jar files if they are missing, as well as some that can automatically convert between .java and .class files. I like this setup, but I'm not dead-set on it. Just thought that I would present it as an option. If you guys would prefer the original version, I can dig. I'll just have to modify mine to use different jar paths than student.